### PR TITLE
Add delay for device ready

### DIFF
--- a/Adafruit_HDC302x.cpp
+++ b/Adafruit_HDC302x.cpp
@@ -13,6 +13,8 @@ Adafruit_HDC302x::Adafruit_HDC302x() { currentAutoMode = EXIT_AUTO_MODE; }
  * @return true if initialization was successful, otherwise false.
  */
 bool Adafruit_HDC302x::begin(uint8_t i2cAddr, TwoWire *wire) {
+  delay(5); // wait for device to be ready
+
   if (i2c_dev) {
     delete i2c_dev;
   }


### PR DESCRIPTION
Adds a simple delay to ensure the HDC302x device is ready before attempting to initialize it. This was brought up in this forum thread:
https://forums.adafruit.com/viewtopic.php?t=214382

Datasheet shows a several ms delay for both power on and reset:
![image](https://github.com/user-attachments/assets/f86ae5ba-775c-4728-ae46-fb63962f72ab)

This PR uses the most conservative 5ms value.

Testing with a Feather ESP32 V2 and the `basicTempHumidity` example from this library.

**BEFORE**
![Screenshot from 2024-10-25 08-50-20](https://github.com/user-attachments/assets/d1571ac6-bf20-45ae-8da6-ba9aa64eb749)

**AFTER**
![Screenshot from 2024-10-25 08-51-00](https://github.com/user-attachments/assets/cc3832ac-7604-4359-b45d-709812f41f3c)

**NOTE** - the first reading is still weird, but that should be dealt with in a separate issue