### PR TITLE
Add conversion wait delay

### DIFF
--- a/Adafruit_HDC302x.cpp
+++ b/Adafruit_HDC302x.cpp
@@ -102,10 +102,12 @@ bool Adafruit_HDC302x::sendCommandReadTRH(uint16_t command, double &temp,
     return false;
   }
 
+  // Wait for conversion (tmeas in datasheet table 7.5)
+  delay(20);
+
+  // Read results
   uint8_t buffer[6];
-  while (!i2c_dev->read(buffer, 6)) {
-    delay(1); // Wait and retry if NAK received
-  }
+  i2c_dev->read(buffer, 6);
 
   // Validate CRC for temperature data
   if (calculateCRC8(buffer, 2) != buffer[2]) {


### PR DESCRIPTION
Potential fix for #2.

This adds a fixed delay between the triggering of an on demand measurement and the reading back of the value. A single value of 20ms is used, which should be a conservative worst case timing based on datasheet:
![image](https://github.com/user-attachments/assets/b52b9e52-600e-407e-b739-c9c7c9f1c78c)

Could add logic to set timing based on low power mode, but the overall sensor response time is on the order of seconds, so seems like overkill.

Tested using a QT PT M0 with the `HDC302x_basicTempHumidity` example from this library.

**BEFORE**
![Screenshot from 2024-11-01 10-58-03](https://github.com/user-attachments/assets/35d40ecd-24eb-4ee0-8a67-7d659dce8d5d)


**AFTER**
![Screenshot from 2024-11-01 10-59-14](https://github.com/user-attachments/assets/91f18a4a-2029-47af-a634-8c275736ea39)

